### PR TITLE
Node struct was refactored.

### DIFF
--- a/Interpreter/Syntax.hpp
+++ b/Interpreter/Syntax.hpp
@@ -1,26 +1,34 @@
 #pragma once
 #include <string>
 #include "Token.hpp"
+#include <memory>
 struct Node : public Token {
-	Node *left;
-	Node *right;
-	Node(std::string const& name, TokenType type = TokenType::unknown, Node *left = nullptr, Node *right = nullptr)
+	std::shared_ptr<Node> left;
+	std::shared_ptr<Node> right;
+	Node(std::string const& name, TokenType type = TokenType::unknown, std::shared_ptr<Node> left = nullptr, std::shared_ptr<Node> right = nullptr)
 		: Token(name, type), left(left), right(right) {}
-	Node(TokenType type = TokenType::unknown, Node *left = nullptr, Node *right = nullptr)
-		: Token("", type), left(left), right(right) {}
-	Node(Token const& token, Node *left = nullptr, Node *right = nullptr) 
+	Node(TokenType type = TokenType::unknown, std::shared_ptr<Node> left = nullptr, std::shared_ptr<Node> right = nullptr)
+		: Node("", type, left, right) {}
+	Node(Token const& token, std::shared_ptr<Node> left = nullptr, std::shared_ptr<Node> right = nullptr)
 		: Node(token.name, token.type, left, right) {}
+	
+	bool operator==(Node const& other) const {
+		return name == other.name && type == other.type;
+	}
+	bool operator<(Node const& other) const {
+		return name < other.name;
+	}
 };
 #include <list>
 #include <set>
 class Syntax {
 public:
-	std::set<Node*> variables;
-	std::set<Node*> constants;
-	Node* graph;
+	std::set<Node> variables;
+	std::set<Node> constants;
+	std::shared_ptr<Node> graph;
 	Syntax(std::list<Token> const& source);
 private:
-	std::list<Node*> parse_brackets(std::list<Node*> source, char bracket_type = 0);
-	Node* parse_graph(std::list<Node*> source);
-	Node* parse_operators(std::list<Node*> source);
+	std::list<std::shared_ptr<Node>> parse_brackets(std::list<std::shared_ptr<Node>> source, char bracket_type = 0);
+	std::shared_ptr<Node> parse_graph(std::list<std::shared_ptr<Node>> source);
+	std::shared_ptr<Node> parse_operators(std::list<std::shared_ptr<Node>> source);
 };

--- a/Interpreter/Syntax_analyzer.cpp
+++ b/Interpreter/Syntax_analyzer.cpp
@@ -1,11 +1,11 @@
 #include "Interpreter.hpp"
-std::list<Node*> convert_to_nodes(std::list<Token> const& source) {
-	std::list<Node*> ret;
+std::list<std::shared_ptr<Node>> convert_to_nodes(std::list<Token> const& source) {
+	std::list<std::shared_ptr<Node>> ret;
 	for (auto it : source)
-		ret.push_back(new Node(it));
+		ret.push_back(std::make_shared<Node>(it));
 	return ret;
 }
-std::list<Node*> Syntax::parse_brackets(std::list<Node*> source, char bracket_type) {
+std::list<std::shared_ptr<Node>> Syntax::parse_brackets(std::list<std::shared_ptr<Node>> source, char bracket_type) {
 	for (auto it = source.begin(); it != source.end(); it++) {
 		if ((*it)->type == TokenType::bracket)
 			if ((*it)->name == "(" || (*it)->name == "[" || (*it)->name == "{") {
@@ -15,7 +15,7 @@ std::list<Node*> Syntax::parse_brackets(std::list<Node*> source, char bracket_ty
 				source.insert(source.end(), nodes.begin(), nodes.end());
 				it = source.begin();
 			} else if (bracket_type && ((*it)->name == ")" || (*it)->name == "]" || (*it)->name == "}")) {
-				Node *ret = new Node("", TokenType::bracket);
+				auto ret = std::make_shared<Node>("", TokenType::bracket);
 				if ((*it)->name == ")" && bracket_type == '(')
 					ret->name = "()";
 				else if ((*it)->name == "}" && bracket_type == '{')
@@ -26,7 +26,7 @@ std::list<Node*> Syntax::parse_brackets(std::list<Node*> source, char bracket_ty
 				if (it == source.begin())
 					ret->right = nullptr;
 				else
-					ret->right = parse_graph(std::list<Node*>{ source.begin(), it });
+					ret->right = parse_graph(std::list<std::shared_ptr<Node>>{ source.begin(), it });
 
 				source = {++it, source.end()};
 				source.push_front(ret);
@@ -35,14 +35,14 @@ std::list<Node*> Syntax::parse_brackets(std::list<Node*> source, char bracket_ty
 	}
 	return source;
 }
-Node* Syntax::parse_operators(std::list<Node*> source) {
+std::shared_ptr<Node> Syntax::parse_operators(std::list<std::shared_ptr<Node>> source) {
 	if (source.size() == 0) {
 		return nullptr;
 	} else if (source.size() == 1) {
 		if (source.front()->type == TokenType::variable_name || source.front()->type == TokenType::list_name || source.front()->type == TokenType::hash_name)
-			variables.insert(source.front());
+			variables.insert(*source.front());
 		else if (source.front()->type == TokenType::int_literal || source.front()->type == TokenType::string_literal)
-			constants.insert(source.front());
+			constants.insert(*source.front());
 		else if (source.front()->type == TokenType::type_name) {
 
 		} else if (source.front()->type == TokenType::reserved_word && (source.front()->name == "shift")) {
@@ -55,12 +55,12 @@ Node* Syntax::parse_operators(std::list<Node*> source) {
 	} else {
 		for (auto it = source.begin(); it != source.end(); it++) {
 			if ((*it)->type == TokenType::semicolon) {
-				auto ret = new Node((*it)->name,
+				auto ret = std::make_shared<Node>((*it)->name,
 									TokenType::semicolon);
 				if (it != source.begin())
-					ret->left = parse_graph(std::list<Node*>{source.begin(), it});
+					ret->left = parse_graph(std::list<std::shared_ptr<Node>>{source.begin(), it});
 				if (it != --source.end())
-					ret->right = parse_graph(std::list<Node*>{++it, source.end()});
+					ret->right = parse_graph(std::list<std::shared_ptr<Node>>{++it, source.end()});
 				return ret;
 			}
 		}
@@ -70,26 +70,27 @@ Node* Syntax::parse_operators(std::list<Node*> source) {
 				it = source.begin();
 			} 
 			if ((*it)->type == TokenType::binary_operator) {
-				auto ret = new Node((*it)->name, TokenType::binary_operator);
-				ret->left = parse_graph(std::list<Node*>{source.begin(), it});
-				ret->right = parse_graph(std::list<Node*>{++it, source.end()});
+				auto ret = std::make_shared<Node>((*it)->name, TokenType::binary_operator);
+				ret->left = parse_graph(std::list<std::shared_ptr<Node>>{source.begin(), it});
+				ret->right = parse_graph(std::list<std::shared_ptr<Node>>{++it, source.end()});
 				return ret;
 			} else if ((*it)->type == TokenType::reserved_word) {
 				if ((*it)->name == "print" || (*it)->name == "package" || (*it)->name == "my" || (*it)->name == "bless" || (*it)->name == "return") {
-					auto ret = new Node((*it)->name, TokenType::reserved_word);
-					ret->right = parse_graph(std::list<Node*>{++it, source.end()});
+					auto ret = std::make_shared<Node>((*it)->name, TokenType::reserved_word);
+					ret->right = parse_graph(std::list<std::shared_ptr<Node>>{++it, source.end()});
 					return ret;
 				} else if ((*it)->name == "sub") {
-						auto ret = new Node((*it)->name, TokenType::reserved_word);
-						ret->left = *(++it);
-						ret->right = parse_graph(std::list<Node*>{++it, source.end()});
-						return ret;
+					auto ret = std::make_shared<Node>((*it)->name, TokenType::reserved_word);
+					ret->left = *(++it);
+					ret->right = parse_graph(std::list<std::shared_ptr<Node>>{++it, source.end()});
+					return ret;
+				}
 			}
 		}
 	}
 	throw std::exception("Some operations are unaccessible for the parser. Recheck code structure.");
 }
-Node* Syntax::parse_graph(std::list<Node*> source) {
+std::shared_ptr<Node> Syntax::parse_graph(std::list<std::shared_ptr<Node>> source) {
 	if (source.size() != 0)
 		return parse_operators(parse_brackets(source));
 	else


### PR DESCRIPTION
Now std::shared_pointer<Node> is used instead of Node*.
It allows to avoid memory leaks.